### PR TITLE
selection of string executable in calculate_string_assembly_index

### DIFF
--- a/assemblytheorytools/assembly.py
+++ b/assemblytheorytools/assembly.py
@@ -797,7 +797,7 @@ def calculate_string_assembly_index(input_data: Union[str, List[str]],
         # Get the assembly code directory
         if dir_code is None:
             dir_code = add_assembly_to_path(str_mode=True)
-
+        
         # Create working directory
         temp_dir = f"ai_calc_{datetime.now().strftime('%H_%M_%f')}" if debug else tempfile.mkdtemp()
         os.makedirs(temp_dir, exist_ok=True)
@@ -1024,7 +1024,13 @@ def add_assembly_to_path(str_mode=False):
     # Check if the environment variable is already set
     if not os.environ.get(key):
         # Default executable name for Linux systems
-        exec_name = "asscpp_combined_static_linux"
+        
+        if str_mode:
+            exec_name = "asscpp_combined_static_strings"
+        else:
+            exec_name = "asscpp_combined_static_linux"
+        
+        
         full_att_path = os.path.join(os.path.dirname(__file__), "precompiled", exec_name)
 
         # Check if the precompiled executable exists


### PR DESCRIPTION
Fixes #336
## What
Fixed selection of correct executable in `calculate_string_assembly_index`
## Why
`calculate_assembly_index` currently uses the `ascpp_combined_static_linux` which has no string assembly functionality. Example behaviour
```
att.calculate_string_assembly_index("ABCABCABC")
Failed to load pathway data: 'Fragments'
(-1, None, None)
```

## How

`add_assembly_to_path` modified to select correct executable

previously:
```
exec_name = "asscpp_combined_static_linux"
```

changed to
```
if str_mode:
        exec_name = "asscpp_combined_static_strings"
else:
        exec_name = "asscpp_combined_static_linux"
```

## Testing
No additional tests fail. Prior failing tests in `test_strings.py` now pass, namely:
```
tests/test_strings.py::test_directed_str_ass
tests/test_strings.py::test_delimiter_chars
tests/test_strings.py::test_directed_joint_str_ass
tests/test_strings.py::test_small_strs
```

Coverage is unaffected