### PR TITLE
Fix wiener_index returning a constant independent of topology

### DIFF
--- a/assemblytheorytools/complexity_scores.py
+++ b/assemblytheorytools/complexity_scores.py
@@ -173,20 +173,18 @@ def wiener_index(mol: Mol) -> int:
     -------
     int
         The Wiener index of the molecule.
+
+    Notes
+    -----
+    - Every atom present in ``mol`` is a vertex of the graph, so molecules
+      carrying explicit hydrogens give a larger index than the heavy-atom
+      skeleton alone. Strip the hydrogens first if the heavy-atom value is
+      wanted.
     """
     distance_matrix = Chem.rdmolops.GetDistanceMatrix(mol)
-    graph = nx.Graph()
-
-    # Add nodes to the graph
-    for i in range(len(distance_matrix)):
-        graph.add_node(i)
-
-    # Add edges with weights based on the distance matrix
-    for i in range(len(distance_matrix)):
-        for j in range(i + 1, len(distance_matrix)):
-            graph.add_edge(i, j, weight=distance_matrix[i, j])
-
-    return nx.wiener_index(graph)
+    # The distance matrix is symmetric with a zero diagonal, so summing every
+    # entry counts each unordered pair of atoms exactly twice.
+    return int(distance_matrix.sum()) // 2
 
 
 def balaban_index(mol: Mol) -> float:

--- a/tests/test_complexity_scores.py
+++ b/tests/test_complexity_scores.py
@@ -87,6 +87,51 @@ def test_count_non_h_bonds():
     assert n == 6, f"Expected 6 non-hydrogen bonds for {smi}, got {n}"
 
 
+def test_wiener_index():
+    """
+    Test the `wiener_index` function against hand-computed values.
+
+    The Wiener index is the sum of the topological shortest-path distances over
+    all unordered pairs of atoms. Every atom present in the molecule counts, so
+    the expected value depends on whether hydrogens are explicit.
+
+    Heavy-atom skeletons (built with `Chem.MolFromSmiles`, which leaves
+    hydrogens implicit):
+    1. Propane ("CCC") is the path C-C-C: 1 + 1 + 2 = 4.
+    2. n-Butane ("CCCC") is the path C-C-C-C: (3x1) + (2x2) + 3 = 10.
+    3. Isobutane ("CC(C)C") is the star K(1,3): (3x1) + (3x2) = 9.
+    4. Benzene ("c1ccccc1") is the 6-cycle: each atom is at distance
+       1, 2, 3, 2, 1 from the others, so 6 x 9 / 2 = 27.
+
+    With explicit hydrogens (as `att.smi_to_mol` adds by default):
+    5. Water ("O") is the path H-O-H: 1 + 1 + 2 = 4.
+    6. Methane ("C") is the star K(1,4): (4x1) + (6x2) = 16.
+
+    Asserts:
+        - Each computed index matches its hand-computed value.
+        - n-Butane and isobutane differ, even though both have four heavy
+          atoms. This guards against a regression in which the index depended
+          only on the atom count and not on the molecular topology.
+    """
+    print(flush=True)
+    # Heavy-atom skeletons: hydrogens stay implicit and so are not vertices
+    heavy_expected = {"CCC": 4, "CCCC": 10, "CC(C)C": 9, "c1ccccc1": 27}
+    for smi, expected in heavy_expected.items():
+        mol = Chem.MolFromSmiles(smi)
+        n = att.wiener_index(mol)
+        assert n == expected, f"Expected Wiener index {expected} for {smi}, got {n}"
+
+    # Same heavy-atom count, different topology, so the indices must differ
+    assert att.wiener_index(Chem.MolFromSmiles("CCCC")) != att.wiener_index(Chem.MolFromSmiles("CC(C)C"))
+
+    # Explicit hydrogens are counted as vertices too
+    h_expected = {"O": 4, "C": 16}
+    for smi, expected in h_expected.items():
+        mol = att.smi_to_mol(smi)  # add_hydrogens defaults to True
+        n = att.wiener_index(mol)
+        assert n == expected, f"Expected Wiener index {expected} for {smi} with hydrogens, got {n}"
+
+
 def test_get_mol_descriptors():
     """
     Test that `get_mol_descriptors()` correctly calculates molecular


### PR DESCRIPTION
wiener_index built a complete graph, joining every pair of atoms with an edge carrying the topological distance as a `weight` attribute, then called nx.wiener_index(graph). nx.wiener_index defaults to weight=None, so it ignored that attribute and treated every edge as length 1. On a complete graph every shortest path is then 1, making the result always n*(n-1)/2 for n atoms -- the same value for any two molecules of equal size, and never the Wiener index.

Sum the RDKit topological distance matrix instead and halve it, since the matrix is symmetric with a zero diagonal. This also makes the return type match the declared `int` (nx.wiener_index returned a float).

Add test_wiener_index, covering hand-computed values for propane (4), n-butane (10), isobutane (9) and benzene (27) as heavy-atom skeletons, plus water (4) and methane (16) with explicit hydrogens. n-butane and isobutane are asserted to differ, which the old implementation could not satisfy.